### PR TITLE
Add one liner evaluation

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -39,6 +39,10 @@ pub struct AppConfig {
     error: bool,
     /// An error message if one occurred.
     error_message: String,
+    /// A value indicating whether to skip undefined result values on JavaScript / TypeScript evaluation.
+    skip_undefined_on_js: bool,
+    /// A value indicating whether to skip empty result values on JavaScript / TypeScript evaluation.
+    skip_empty_on_js: bool,
 }
 
 // The default value for the application configuration.
@@ -50,6 +54,8 @@ impl ::std::default::Default for AppConfig {
             error: false,
             error_message: "".to_string(),
             dark_mode: false,
+            skip_undefined_on_js: true,
+            skip_empty_on_js: true,
         }
     }
 }

--- a/src-tauri/src/js_helpers.rs
+++ b/src-tauri/src/js_helpers.rs
@@ -24,19 +24,21 @@ SOFTWARE.
 
 use std::sync::Mutex;
 
-static mut LOG_STACK: Mutex<Vec<String>> = Mutex::new(vec![]);
+use crate::types::LineByLineLog;
 
-/// Pushes a new captured log call values to the log stack.
+static mut LOG_STACK: Mutex<Vec<String>> = Mutex::new(vec![]);
+static mut LOG_STACK_LINES: Mutex<Vec<LineByLineLog>> = Mutex::new(vec![]);
+static mut FILE_LINE: Mutex<Option<i32>> = Mutex::new(None);
+
+/// Formats the v8 log call arguments to a string.
 ///
 /// # Arguments
 /// * `scope` - The v8 scope.
 /// * `args` - The v8 arguments.
-/// * `_rv` - The v8 return value.
-pub fn js_console_log_capture(
-    scope: &mut v8::HandleScope,
-    args: v8::FunctionCallbackArguments,
-    mut _rv: v8::ReturnValue,
-) {
+///
+/// # Returns
+/// The formatted log call string.
+fn format_js_log(scope: &mut v8::HandleScope, args: v8::FunctionCallbackArguments) -> String {
     let mut result: Vec<String> = Vec::new();
     let length = args.length();
     for i in 0..length {
@@ -50,7 +52,21 @@ pub fn js_console_log_capture(
 
     let result = result.join(" ");
 
-    push_log_stack(format!("LOG: {}", result));
+    result
+}
+
+/// Pushes a new captured log call values to the log stack.
+///
+/// # Arguments
+/// * `scope` - The v8 scope.
+/// * `args` - The v8 arguments.
+/// * `_rv` - The v8 return value.
+pub fn js_console_log_capture(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut _rv: v8::ReturnValue,
+) {
+    push_log_stack(format!("LOG: {}", format_js_log(scope, args)));
 }
 
 /// Pushes a new captured warn call values to the log stack.
@@ -64,19 +80,7 @@ pub fn js_console_warn_capture(
     args: v8::FunctionCallbackArguments,
     mut _rv: v8::ReturnValue,
 ) {
-    let mut result: Vec<String> = Vec::new();
-    for i in 0..args.length() {
-        let arg = args
-            .get(i)
-            .to_string(scope)
-            .unwrap()
-            .to_rust_string_lossy(scope);
-        result.push(arg);
-    }
-
-    let result = result.join(" ");
-
-    push_log_stack(format!("WARN: {}", result));
+    push_log_stack(format!("WARN: {}", format_js_log(scope, args)));
 }
 
 /// Pushes a new captured error call values to the log stack.
@@ -90,19 +94,49 @@ pub fn js_console_error_capture(
     args: v8::FunctionCallbackArguments,
     mut _rv: v8::ReturnValue,
 ) {
-    let mut result: Vec<String> = Vec::new();
-    for i in 0..args.length() {
-        let arg = args
-            .get(i)
-            .to_string(scope)
-            .unwrap()
-            .to_rust_string_lossy(scope);
-        result.push(arg);
-    }
+    push_log_stack(format!("ERROR: {}", format_js_log(scope, args)));
+}
 
-    let result = result.join(" ");
+/// Pushes a new captured log call values to the log stack.
+///
+/// # Arguments
+/// * `scope` - The v8 scope.
+/// * `args` - The v8 arguments.
+/// * `_rv` - The v8 return value.
+pub fn js_console_log_capture_lines(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut _rv: v8::ReturnValue,
+) {
+    push_log_stack_file_line(format!("LOG: {}", format_js_log(scope, args)));
+}
 
-    push_log_stack(format!("ERROR: {}", result));
+/// Pushes a new captured warn call values to the log stack.
+///
+/// # Arguments
+/// * `scope` - The v8 scope.
+/// * `args` - The v8 arguments.
+/// * `_rv` - The v8 return value.
+pub fn js_console_warn_capture_lines(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut _rv: v8::ReturnValue,
+) {
+    push_log_stack_file_line(format!("WARN: {}", format_js_log(scope, args)));
+}
+
+/// Pushes a new captured error call values to the log stack.
+///
+/// # Arguments
+/// * `scope` - The v8 scope.
+/// * `args` - The v8 arguments.
+/// * `_rv` - The v8 return value.
+pub fn js_console_error_capture_lines(
+    scope: &mut v8::HandleScope,
+    args: v8::FunctionCallbackArguments,
+    mut _rv: v8::ReturnValue,
+) {
+    push_log_stack_file_line(format!("ERROR: {}", format_js_log(scope, args)));
 }
 
 /// Pushes a specified value to the log stack.
@@ -120,12 +154,76 @@ pub fn push_log_stack(value: String) {
     }
 }
 
+pub fn set_file_line(file_line: Option<i32>) {
+    unsafe {
+        match FILE_LINE.lock() {
+            Ok(mut file_line_mutex) => {
+                *file_line_mutex = file_line;
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+pub fn push_log_stack_file_line(value: String) {
+    unsafe {
+        match FILE_LINE.lock() {
+            Ok(file_line) => match *file_line {
+                Some(file_line) => {
+                    match LOG_STACK_LINES.lock() {
+                        Ok(mut log_stack) => {
+                            let stack = log_stack
+                                .iter_mut()
+                                .find(|line| line.line_number == file_line);
+
+                            match stack {
+                                Some(stack) => {
+                                    stack.lines.push(value);
+                                }
+                                None => {
+                                    log_stack.push(LineByLineLog {
+                                        line_number: file_line,
+                                        lines: vec![value],
+                                    });
+                                }
+                            }
+                        }
+                        Err(_) => {
+                            push_log_stack(value);
+                        }
+                    };
+                }
+                None => {
+                    push_log_stack(value);
+                }
+            },
+            Err(_) => {
+                push_log_stack(value);
+            }
+        }
+    }
+}
+
 /// Clears the log stack.
 pub fn clear_log_stack() {
     unsafe {
         match LOG_STACK.lock() {
             Ok(mut stack) => {
                 stack.clear();
+            }
+            Err(_) => {}
+        }
+
+        match LOG_STACK_LINES.lock() {
+            Ok(mut stack) => {
+                stack.clear();
+            }
+            Err(_) => {}
+        }
+
+        match FILE_LINE.lock() {
+            Ok(mut file_line) => {
+                *file_line = None;
             }
             Err(_) => {}
         }
@@ -139,6 +237,19 @@ pub fn clear_log_stack() {
 pub fn get_log_stack() -> Vec<String> {
     unsafe {
         match LOG_STACK.lock() {
+            Ok(stack) => stack.clone(),
+            Err(_) => vec![],
+        }
+    }
+}
+
+/// Gets the log stack by file line.
+///
+/// # Returns
+/// The log stack as a vector of file line numbers and their corresponding lines.
+pub fn get_log_stack_by_file_line() -> Vec<LineByLineLog> {
+    unsafe {
+        match LOG_STACK_LINES.lock() {
             Ok(stack) => stack.clone(),
             Err(_) => vec![],
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,7 @@ pub async fn run() {
             save_settings,
             get_app_state,
             run_script,
+            run_script_line_by_line,
             save_open_tabs,
             add_new_tab,
             update_open_tabs,
@@ -96,6 +97,15 @@ async fn save_settings(config: AppConfig) -> bool {
 #[tauri::command]
 async fn run_script(code: String, app_state: State<'_, AppState>) -> Result<String, String> {
     TauriCommands::run_script(code, app_state).await
+}
+
+/// See [TauriCommands::run_script_line_by_line]
+#[tauri::command]
+async fn run_script_line_by_line(
+    code: Vec<String>,
+    app_state: State<'_, AppState>,
+) -> Result<Vec<String>, String> {
+    TauriCommands::run_script_line_by_line(code, app_state).await
 }
 
 /// See [TauriCommands::save_open_tabs]

--- a/src-tauri/src/tauri_commands_fs.rs
+++ b/src-tauri/src/tauri_commands_fs.rs
@@ -69,6 +69,7 @@ impl TauriCommands {
                         modified_at: tab.modified_at.clone(),
                         file_name_path: tab.file_name_path.clone(),
                         modified_at_state: tab.modified_at_state.clone(),
+                        evalueate_per_line: tab.evalueate_per_line,
                     },
                     None => {
                         return Err("Failed to find the file in application state.".to_string());
@@ -192,6 +193,7 @@ impl TauriCommands {
                     modified_at: modified_at,
                     file_name_path: Some(file_name_path),
                     modified_at_state: modified_at,
+                    evalueate_per_line: false,
                 };
                 tab_data
             }

--- a/src-tauri/src/tauri_commands_tabs.rs
+++ b/src-tauri/src/tauri_commands_tabs.rs
@@ -185,6 +185,16 @@ impl TauriCommands {
             }
         };
 
+        let log_stack_lines = match app_state.log_stack_lines.lock() {
+            Ok(lines) => {
+                let log_stack_lines = lines.clone();
+                log_stack_lines
+            }
+            Err(_) => {
+                return Err("Error: Failed to get application state.".to_string());
+            }
+        };
+
         match app_state.log_stack.lock() {
             Ok(stack) => {
                 let log_stack = stack.clone();
@@ -192,6 +202,7 @@ impl TauriCommands {
                     log_stack,
                     file_tabs,
                     file_ids,
+                    log_stack_lines,
                 });
             }
             Err(_) => {

--- a/src-tauri/src/tauri_commans_script.rs
+++ b/src-tauri/src/tauri_commans_script.rs
@@ -26,8 +26,9 @@ use tauri::State;
 
 use crate::{
     js_helpers::{
-        clear_log_stack, get_log_stack, js_console_error_capture, js_console_log_capture,
-        js_console_warn_capture,
+        clear_log_stack, get_log_stack, get_log_stack_by_file_line, js_console_error_capture,
+        js_console_error_capture_lines, js_console_log_capture, js_console_log_capture_lines,
+        js_console_warn_capture, js_console_warn_capture_lines, set_file_line,
     },
     tauri_commands::TauriCommands,
     types::AppState,
@@ -121,5 +122,113 @@ impl TauriCommands {
         }
 
         Ok(result)
+    }
+
+    /// Runs the script passed from the frontend.
+    ///
+    /// # Arguments
+    /// `code` - The script code lines to evaluate.
+    /// `app_state` - The Tauri application state.
+    ///
+    /// # Returns
+    /// The result of the script run line by line.    
+    pub async fn run_script_line_by_line(
+        mut code: Vec<String>,
+        app_state: State<'_, AppState>,
+    ) -> Result<Vec<String>, String> {
+        clear_log_stack();
+
+        match app_state.log_stack_lines.lock() {
+            Ok(mut stack) => {
+                *stack = vec![];
+            }
+            Err(_) => {}
+        }
+
+        // The console.log(), console.warn(), and console.error() functions are not
+        // outputted anywhere, so we need to replace them with our own functions.
+        for i in 0..code.len() {
+            code[i] = code[i]
+                .replace("console.log(", "console_log(")
+                .replace("console.warn(", "console_warn(")
+                .replace("console.error(", "console_error(");
+        }
+
+        let isolate = &mut v8::Isolate::new(Default::default());
+
+        let scope = &mut v8::HandleScope::new(isolate);
+        let context = v8::Context::new(scope);
+        let scope = &mut v8::ContextScope::new(scope, context);
+
+        let object_template = v8::ObjectTemplate::new(scope);
+
+        // Bind the console.log() function to a custom capture function which will update the data into the Tauri application state.
+        let function_template = v8::FunctionTemplate::new(scope, js_console_log_capture_lines);
+        let name = v8::String::new(scope, "console_log").unwrap();
+        object_template.set(name.into(), function_template.into());
+        // Bind the console.warn() function to a custom capture function which will update the data into the Tauri application state.
+        let function_template = v8::FunctionTemplate::new(scope, js_console_warn_capture_lines);
+        let name = v8::String::new(scope, "console_warn").unwrap();
+        object_template.set(name.into(), function_template.into());
+        // Bind the console.error() function to a custom capture function which will update the data into the Tauri application state.
+        let function_template = v8::FunctionTemplate::new(scope, js_console_error_capture_lines);
+        let name = v8::String::new(scope, "console_error").unwrap();
+        object_template.set(name.into(), function_template.into());
+
+        let context = v8::Context::new_from_template(scope, object_template);
+
+        let mut result_all: Vec<String> = Vec::new();
+
+        for i in 0..code.len() {
+            set_file_line(Some(i as i32));
+            let code = code[i].as_str();
+
+            let scope = &mut v8::ContextScope::new(scope, context);
+
+            let source = match v8::String::new(scope, code) {
+                Some(source) => source,
+                None => {
+                    result_all.push("Failed to create script.".to_string());
+                    continue;
+                }
+            };
+
+            let script = match v8::Script::compile(scope, source, None) {
+                Some(script) => script,
+                None => {
+                    result_all.push("Failed to compile script.".to_string());
+                    continue;
+                }
+            };
+
+            let result = match script.run(scope) {
+                Some(result) => result,
+                None => {
+                    result_all.push("Failed to run script.".to_string());
+                    continue;
+                }
+            };
+
+            let result = match result.to_string(scope) {
+                Some(result) => result.to_rust_string_lossy(scope),
+                None => {
+                    result_all.push(
+                        "Failed to convert compiled script and results to string.".to_string(),
+                    );
+                    continue;
+                }
+            };
+
+            result_all.push(result);
+        }
+
+        match app_state.log_stack_lines.lock() {
+            Ok(mut stack) => *stack = get_log_stack_by_file_line(),
+            Err(_) => {}
+        }
+
+        set_file_line(None);
+
+        Ok(result_all)
     }
 }

--- a/src-tauri/src/tauri_commans_script.rs
+++ b/src-tauri/src/tauri_commans_script.rs
@@ -180,6 +180,11 @@ impl TauriCommands {
         let mut result_all: Vec<String> = Vec::new();
 
         for i in 0..code.len() {
+            // Skip empty lines
+            if code[i].trim() == "" {
+                continue;
+            }
+
             set_file_line(Some(i as i32));
             let code = code[i].as_str();
 

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -27,10 +27,18 @@ use std::sync::Mutex;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+#[derive(Serialize, Deserialize, Clone)]
+pub struct LineByLineLog {
+    pub line_number: i32,
+    pub lines: Vec<String>,
+}
+
 /// The application state for the Tauri application.
 pub struct AppState {
     /// The log stack for the run script.
     pub log_stack: Mutex<Vec<String>>,
+    /// The log stack lines for the run script.
+    pub log_stack_lines: Mutex<Vec<LineByLineLog>>,
     /// The index of the next file.
     pub file_ids: Mutex<Vec<i32>>,
     /// The file tabs currently open.
@@ -44,6 +52,7 @@ impl ::std::default::Default for AppState {
             log_stack: Mutex::new(vec![]),
             file_ids: Mutex::new(vec![]),
             file_tabs: Mutex::new(vec![]),
+            log_stack_lines: Mutex::new(vec![]),
         }
     }
 }
@@ -53,6 +62,8 @@ impl ::std::default::Default for AppState {
 pub struct AppStateResult {
     /// The log stack for the run script.
     pub log_stack: Vec<String>,
+    /// The log stack lines for the run script.
+    pub log_stack_lines: Vec<LineByLineLog>,
     /// The index of the next file.
     pub file_ids: Vec<i32>,
     /// The file tabs currently open.
@@ -80,4 +91,6 @@ pub struct FileTabData {
     pub modified_at: Option<DateTime<Utc>>,
     /// A flag indicating if the file differs from the file system.
     pub modified_at_state: Option<DateTime<Utc>>,
+    /** A flag indicating whether to evaluate each line separately or the entire file content at once. */
+    pub evalueate_per_line: bool,
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,11 +101,11 @@ const App = ({ className }: AppProps) => {
         if (activeTabKey) {
             const tabScript = fileTabs.find(tab => tab.uid === activeTabKey);
 
-            if (tabScript) {
+            if (tabScript && settings) {
                 if (tabScript.evalueate_per_line) {
-                    evalueateValueByLines(tabScript.content, true, true, tabScript.script_language, translate)
+                    evalueateValueByLines(tabScript.content, settings.skip_undefined_on_js, settings.skip_empty_on_js, tabScript.script_language)
                         .then(value => {
-                            setEvaluationResult(value);
+                            setEvaluationResult(value.map(f => `${translate("line", "Line")} ${f}`));
                         })
                         .catch(error => notification("error", error));
                 } else {
@@ -117,7 +117,7 @@ const App = ({ className }: AppProps) => {
                 }
             }
         }
-    }, [activeTabKey, fileTabs, notification, translate]);
+    }, [activeTabKey, fileTabs, notification, settings, translate]);
 
     // Load the initial application state consisting of the file tabs and related data.
     React.useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useState } from "react";
 import { styled } from "styled-components";
 import { Editor } from "@monaco-editor/react";
 import "./App.css";
@@ -36,7 +35,7 @@ import { transpileTypeSctiptToJs } from "./utilities/app/TypeSciptTranspile";
 import { ToolBarItems } from "./menu/ToolbarItems";
 import { DialogButtons, DialogResult, PopupType } from "./components/Enums";
 import { ConfirmPopup } from "./components/popups/ConfirmPopup";
-import { evalueateValue } from "./utilities/app/Code";
+import { evalueateValue, evalueateValueByLines } from "./utilities/app/Code";
 
 type AppProps = CommonProps;
 
@@ -57,12 +56,12 @@ const App = ({ className }: AppProps) => {
     );
 
     // State variables.
-    const [evaluationResult, setEvaluationResult] = useState("");
+    const [evaluationResult, setEvaluationResult] = React.useState<string | string[]>("");
     const [aboutPopupVisible, setAboutPopupVisible] = React.useState(false);
     const [preferencesVisible, setPreferencesVisible] = React.useState(false);
     const [settings, settingsLoaded, updateSettings, reloadSettings] = useSettings(settingsErrorCallback);
     const [previewDarkMode, setPreviewDarkMode] = React.useState<boolean | null>(null);
-    const [selectedValues, setSelectedValues] = React.useState<{ [key: string]: string }>({ language: "javascript" });
+    const [selectedValues, setSelectedValues] = React.useState<{ [key: string]: unknown }>({ language: "javascript", oneLineEvaluation: false });
     const [fileTabs, setFileTabs] = React.useState<FileTabData[]>([]);
     const [activeTabKey, setActiveTabKey] = React.useState(0);
     const [disabledItems, setDisabledItems] = React.useState<(MenuKeys | ToolBarItems)[]>([]);
@@ -70,6 +69,18 @@ const App = ({ className }: AppProps) => {
 
     const fileNameRef = React.useRef<string>("");
     const previousFocusedRef = React.useRef<boolean>(false);
+
+    const setSelectedValue = React.useCallback(
+        (key: "language" | "oneLineEvaluation", value: unknown) => {
+            if (selectedValues[key] === value) {
+                return;
+            }
+            const values = { ...selectedValues };
+            values[key] = value;
+            setSelectedValues(values);
+        },
+        [selectedValues]
+    );
 
     // Antd theme-related hooks.
     const { token } = useAntdToken();
@@ -91,20 +102,29 @@ const App = ({ className }: AppProps) => {
             const tabScript = fileTabs.find(tab => tab.uid === activeTabKey);
 
             if (tabScript) {
-                evalueateValue(tabScript.content, tabScript.script_language)
-                    .then(value => {
-                        setEvaluationResult(value);
-                    })
-                    .catch(error => notification("error", error));
+                if (tabScript.evalueate_per_line) {
+                    evalueateValueByLines(tabScript.content, true, true, tabScript.script_language, translate)
+                        .then(value => {
+                            setEvaluationResult(value);
+                        })
+                        .catch(error => notification("error", error));
+                } else {
+                    evalueateValue(tabScript.content, true, tabScript.script_language)
+                        .then(value => {
+                            setEvaluationResult(value);
+                        })
+                        .catch(error => notification("error", error));
+                }
             }
         }
-    }, [activeTabKey, fileTabs, notification]);
+    }, [activeTabKey, fileTabs, notification, translate]);
 
     // Load the initial application state consisting of the file tabs and related data.
     React.useEffect(() => {
-        if (appStateLoaded.current && !settingsLoaded) {
+        if (appStateLoaded.current && settingsLoaded) {
             return;
         }
+
         loadFileState()
             .then(() => {
                 getAppState()
@@ -134,23 +154,31 @@ const App = ({ className }: AppProps) => {
     }, [fileTabs, activeTabKey, notification]);
 
     // Enable or disable the specified menu or toolbar item.
-    const enableDisableMenuToolbarItem = React.useCallback((mtItem: MenuKeys | ToolBarItems, enabled: boolean) => {
-        if (enabled) {
-            setDisabledItems(f => f.filter(item => item !== mtItem));
-        } else {
-            setDisabledItems(f => (f.includes(mtItem) ? f : [...f, mtItem]));
-        }
-    }, []);
+    const enableDisableMenuToolbarItem = React.useCallback(
+        (mtItem: MenuKeys | ToolBarItems, enabled: boolean) => {
+            if (enabled) {
+                if (disabledItems.includes(mtItem)) {
+                    setDisabledItems(f => f.filter(item => item !== mtItem));
+                }
+            } else {
+                if (!disabledItems.includes(mtItem)) {
+                    setDisabledItems(f => (f.includes(mtItem) ? f : [...f, mtItem]));
+                }
+            }
+        },
+        [disabledItems]
+    );
 
     // Disable the "Convert to JavaScript" menu item if the currently selected file is not a JavaScript file.
     React.useEffect(() => {
         const tabScript = fileTabs.find(tab => tab.uid === activeTabKey);
         if (tabScript) {
             enableDisableMenuToolbarItem("convertToJs", tabScript.script_language === "typescript");
+            setSelectedValue("oneLineEvaluation", tabScript.evalueate_per_line);
 
             checkTabFileChanged();
         }
-    }, [fileTabs, activeTabKey, notification, checkTabFileChanged, enableDisableMenuToolbarItem]);
+    }, [activeTabKey, checkTabFileChanged, enableDisableMenuToolbarItem, fileTabs, setSelectedValue]);
 
     // Restore the window state.
     React.useEffect(() => {
@@ -267,7 +295,7 @@ const App = ({ className }: AppProps) => {
 
     // A callback to handle menu item and toolbar item clicks.
     const onMenuItemClick = React.useCallback(
-        (key: unknown) => {
+        (key: unknown, checked?: boolean) => {
             const keyValue = key as MenuKeys;
             switch (keyValue) {
                 case "exitMenu": {
@@ -308,6 +336,7 @@ const App = ({ className }: AppProps) => {
                                 modified_at: null,
                                 file_name_path: null,
                                 modified_at_state: new Date(),
+                                evalueate_per_line: false,
                             })
                                 .then(() => {
                                     saveAppStateReload().catch(error => notification("error", error));
@@ -359,13 +388,25 @@ const App = ({ className }: AppProps) => {
                     evaluateActiveCode();
                     break;
                 }
+                case "oneLineEvaluation": {
+                    setSelectedValue("oneLineEvaluation", checked ?? false);
+
+                    const tabs = [...fileTabs];
+                    const index = tabs.findIndex(f => f.uid === activeTabKey);
+                    if (index !== -1) {
+                        const tab = fileTabs[index];
+                        tab.evalueate_per_line = !tab.evalueate_per_line;
+                        setFileTabs(tabs);
+                    }
+                    break;
+                }
                 default: {
                     break;
                 }
             }
         },
         [
-            activeTabKey, //
+            activeTabKey,
             appWindow,
             evaluateActiveCode,
             fileTabs,
@@ -375,6 +416,7 @@ const App = ({ className }: AppProps) => {
             saveAppStateReload,
             saveFileCallback,
             selectedValues,
+            setSelectedValue,
             translate,
         ]
     );
@@ -426,7 +468,7 @@ const App = ({ className }: AppProps) => {
 
     // A callback to set the script evaluation result in the state.
     const onNewOutput = React.useCallback(
-        (output: string) => {
+        (output: string | string[]) => {
             setEvaluationResult(output);
         },
         [setEvaluationResult]
@@ -476,6 +518,10 @@ const App = ({ className }: AppProps) => {
         [reloadAppState, reloadCurrentFileContents]
     );
 
+    const evaluateEditorValue = React.useMemo(() => {
+        return Array.isArray(evaluationResult) ? evaluationResult.join("\n") : evaluationResult;
+    }, [evaluationResult]);
+
     // Render loading indicator if the settings and app state are not loaded yet.
     if (!settingsLoaded || settings === null || appStateLoaded.current === false) {
         return <div>Loading...</div>;
@@ -519,7 +565,7 @@ const App = ({ className }: AppProps) => {
                         <Editor //
                             theme={previewDarkMode ?? settings.dark_mode ?? false ? "vs-dark" : "light"}
                             className="EditorResult"
-                            value={evaluationResult}
+                            value={evaluateEditorValue}
                         />
                     </div>
                 </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -558,6 +558,7 @@ const App = ({ className }: AppProps) => {
                         saveFileTabs={saveFileTabs}
                         saveTab={saveFileCallback}
                         notification={notification}
+                        settings={settings}
                     />
                     <div className="EditorResultContainer">
                         {translate("result", "Result")}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -550,7 +550,6 @@ const App = ({ className }: AppProps) => {
                     <TabbedEditor //
                         darkMode={previewDarkMode ?? settings.dark_mode ?? false}
                         onNewOutput={onNewOutput}
-                        activeTabScriptType={selectedValues["language"] as ScriptType}
                         fileTabs={fileTabs}
                         activeTabKey={activeTabKey}
                         setActiveTabKey={setActiveTabKey}

--- a/src/components/Types.ts
+++ b/src/components/Types.ts
@@ -30,6 +30,8 @@ type FileTabData = {
     modified_at: Date | null;
     /** The last modified date of the file in the application state. */
     modified_at_state: Date | null;
+    /** A flag indicating whether to evaluate each line separately or the entire file content at once. */
+    evalueate_per_line: boolean;
 };
 
 type ScriptType = "typescript" | "javascript";

--- a/src/components/app/TabbedEditor.tsx
+++ b/src/components/app/TabbedEditor.tsx
@@ -42,7 +42,6 @@ import { evalueateValue, evalueateValueByLines } from "../../utilities/app/Code"
 type TabbedEditorProps = {
     darkMode: boolean;
     fileTabs: FileTabData[];
-    activeTabScriptType: ScriptType;
     activeTabKey: number;
     setActiveTabKey: (value: number) => void;
     saveFileTabs: () => void;
@@ -62,7 +61,6 @@ const TabbedEditorComponent = ({
     className, //
     darkMode,
     fileTabs = [],
-    activeTabScriptType,
     activeTabKey,
     setActiveTabKey,
     saveFileTabs,

--- a/src/components/app/TabbedEditor.tsx
+++ b/src/components/app/TabbedEditor.tsx
@@ -34,7 +34,7 @@ import { ConfirmPopup } from "../popups/ConfirmPopup";
 import { DialogButtons, DialogResult, PopupType } from "../Enums";
 import { useTranslate } from "../../localization/Localization";
 import { NotificationType } from "../../utilities/app/Notify";
-import { evalueateValue } from "../../utilities/app/Code";
+import { evalueateValue, evalueateValueByLines } from "../../utilities/app/Code";
 
 /**
  * The props for the {@link TabbedEditor} component.
@@ -48,7 +48,7 @@ type TabbedEditorProps = {
     saveFileTabs: () => void;
     setActiveTabScriptType: (scriptType: ScriptType) => void;
     setFileTabs: (fileTabs: FileTabData[]) => void;
-    onNewOutput: (output: string) => void;
+    onNewOutput: (output: string | string[]) => void;
     saveTab: (activeTabKey: number) => Promise<boolean>;
     notification: (type: NotificationType, title: string | null | undefined | Error | unknown, duration?: number) => void;
 } & CommonProps;
@@ -134,17 +134,18 @@ const TabbedEditorComponent = ({
     const evalueateCallback = React.useCallback(async () => {
         const tab = fileTabs.find(f => f.uid === activeTabKey);
         const editorValue = tab?.content;
-        if (editorValue !== undefined && editorValue !== null) {
-            let value = "";
+        if (editorValue !== undefined && editorValue !== null && tab !== undefined) {
+            let value: string | string[] = "";
+
             try {
-                value = await evalueateValue(editorValue, activeTabScriptType);
+                value = await (tab?.evalueate_per_line ? evalueateValueByLines(editorValue, true, true, tab.script_language, translate) : evalueateValue(editorValue, true, tab.script_language));
             } catch (error) {
                 notification("error", error);
             }
 
             onNewOutput(value);
         }
-    }, [activeTabKey, activeTabScriptType, fileTabs, notification, onNewOutput]);
+    }, [activeTabKey, fileTabs, notification, onNewOutput, translate]);
 
     useDebounce(evalueateCallback, 1_500);
 

--- a/src/components/app/TauriWrappers.ts
+++ b/src/components/app/TauriWrappers.ts
@@ -25,8 +25,14 @@ SOFTWARE.
 import { invoke } from "@tauri-apps/api/core";
 import { FileTabData } from "../Types";
 
+type LineByLineLog = {
+    line_number: number;
+    lines: string[];
+};
+
 type AppStateResult = {
     log_stack: string[];
+    log_stack_lines: LineByLineLog[];
     file_ids: number[];
     file_tabs: FileTabData[];
 };
@@ -40,6 +46,14 @@ type AppStateResult = {
 const runScript = async (code: string): Promise<string> => {
     try {
         return await invoke("run_script", { code });
+    } catch (error) {
+        throw new Error(`${error}`);
+    }
+};
+
+const runScriptLineByLine = async (code: string[]): Promise<string[]> => {
+    try {
+        return await invoke("run_script_line_by_line", { code });
     } catch (error) {
         throw new Error(`${error}`);
     }
@@ -190,6 +204,7 @@ const saveFileContents = async (data: FileTabData, fileNamePath: string | null) 
 export {
     //
     runScript,
+    runScriptLineByLine,
     getAppState,
     addNewTab,
     saveOpenTabs,
@@ -202,4 +217,4 @@ export {
     saveFileContents,
 };
 
-export type { AppStateResult };
+export type { AppStateResult, LineByLineLog };

--- a/src/components/popups/PreferencesPopup.tsx
+++ b/src/components/popups/PreferencesPopup.tsx
@@ -25,7 +25,7 @@ SOFTWARE.
 import * as React from "react";
 import classNames from "classnames";
 import { styled } from "styled-components";
-import { Button, Checkbox, Modal, Select } from "antd";
+import { Button, Checkbox, Modal, Select, Tooltip } from "antd";
 import { CheckboxChangeEvent } from "antd/es/checkbox";
 import { Settings } from "../../utilities/app/Settings";
 import { CommonProps } from "../Types";
@@ -99,6 +99,20 @@ const PreferencesPopupComponent = ({
         [settingsInternal, toggleDarkMode]
     );
 
+    const setSkipUndefinedOnJs = React.useCallback(
+        (e: CheckboxChangeEvent) => {
+            setSettingsInternal({ ...settingsInternal, skip_undefined_on_js: e.target.checked === true });
+        },
+        [settingsInternal]
+    );
+
+    const setSkipEmptyOnJs = React.useCallback(
+        (e: CheckboxChangeEvent) => {
+            setSettingsInternal({ ...settingsInternal, skip_empty_on_js: e.target.checked === true });
+        },
+        [settingsInternal]
+    );
+
     // The OK button was clicked.
     const onOkClick = React.useCallback(() => {
         void updateSettings(settingsInternal)
@@ -161,6 +175,30 @@ const PreferencesPopupComponent = ({
                                 <Checkbox //
                                     checked={settingsInternal.dark_mode}
                                     onChange={setDarkMode}
+                                />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <Tooltip title={translate("skipUndefinedOnCodeEvaluationExplanation")}>
+                                    <div>{translate("skipUndefinedOnCodeEvaluation")}</div>
+                                </Tooltip>
+                            </td>
+                            <td>
+                                <Checkbox //
+                                    checked={settingsInternal.skip_undefined_on_js}
+                                    onChange={setSkipUndefinedOnJs}
+                                />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                <div>{translate("skipEnptyLinesOnResults")}</div>
+                            </td>
+                            <td>
+                                <Checkbox //
+                                    checked={settingsInternal.skip_empty_on_js}
+                                    onChange={setSkipEmptyOnJs}
                                 />
                             </td>
                         </tr>

--- a/src/components/wrappers/ToolTipObjectToggleButton.tsx
+++ b/src/components/wrappers/ToolTipObjectToggleButton.tsx
@@ -1,0 +1,88 @@
+/*
+MIT License
+
+Copyright (c) 2024 VPKSoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import * as React from "react";
+import { styled } from "styled-components";
+import classNames from "classnames";
+import { Radio, Tooltip } from "antd";
+import { CommonProps } from "../Types";
+
+/**
+ * The props for the {@link ToolTipObjectToggleButton} component.
+ */
+type ToolTipObjectToggleButtonProps<T> = {
+    icon?: React.ReactNode;
+    objectData: T;
+    children?: React.ReactNode;
+    tooltipTitle: string;
+    disabled?: boolean;
+    checked: boolean;
+    onClick: (objectData: T | undefined, checked?: boolean) => void;
+} & CommonProps;
+
+/**
+ * A toggle button component for toolbar.
+ * @param param0 The component props: {@link ToolTipObjectToggleButtonProps}.
+ * @returns A component.
+ */
+const ToolTipObjectToggleButtonComponent = <T,>({
+    className, //
+    tooltipTitle,
+    key,
+    disabled = false,
+    objectData,
+    icon,
+    checked,
+    onClick,
+}: ToolTipObjectToggleButtonProps<T>) => {
+    const onClickHandler = React.useCallback(() => {
+        onClick(objectData, !checked);
+    }, [objectData, onClick, checked]);
+
+    return (
+        <Tooltip title={tooltipTitle} key={key}>
+            <Radio.Group //
+                buttonStyle="solid"
+                optionType="button"
+                value={checked ? objectData : undefined}
+            >
+                <Radio //
+                    className={classNames(ToolTipObjectToggleButton.name, className)}
+                    checked={checked}
+                    onClick={onClickHandler}
+                    disabled={disabled}
+                    value={objectData}
+                >
+                    {icon}
+                </Radio>
+            </Radio.Group>
+        </Tooltip>
+    );
+};
+
+const ToolTipObjectToggleButton = styled(ToolTipObjectToggleButtonComponent)`
+    // Add style(s) here
+`;
+
+export { ToolTipObjectToggleButton };

--- a/src/localization/Localization.ts
+++ b/src/localization/Localization.ts
@@ -6,10 +6,12 @@ import uiEnglish from "../localization/en/ui.json";
 import messagesEnglish from "../localization/en/messages.json";
 import settingsEnglish from "../localization/en/settings.json";
 import dialogEnglish from "../localization/en/dialog.json";
+import longTextsEnglish from "../localization/en/long_texts.json";
 import uiFinnish from "../localization/fi/ui.json";
 import messagesFinnish from "../localization/fi/messages.json";
 import settingsFinnish from "../localization/fi/settings.json";
 import dialogFinnish from "../localization/fi/dialog.json";
+import longTextsFinnish from "../localization/fi/long_texts.json";
 
 const localizationResources = {
     en: {
@@ -17,18 +19,20 @@ const localizationResources = {
         messages: messagesEnglish,
         settings: settingsEnglish,
         dialog: dialogEnglish,
+        longTexts: longTextsEnglish,
     },
     fi: {
         ui: uiFinnish,
         messages: messagesFinnish,
         settings: settingsFinnish,
         dialog: dialogFinnish,
+        longTexts: longTextsFinnish,
     },
 };
 
 export type Locales = keyof typeof localizationResources;
 export type LocalizationResources = keyof (typeof localizationResources)[Locales];
-export type LocalizationNames = keyof typeof uiEnglish | keyof typeof messagesEnglish | keyof typeof settingsEnglish | keyof typeof dialogEnglish;
+export type LocalizationNames = keyof typeof uiEnglish | keyof typeof messagesEnglish | keyof typeof settingsEnglish | keyof typeof dialogEnglish | keyof typeof longTextsEnglish;
 const resourceArray = Object.keys(localizationResources["en"]);
 
 const defaultLanguage: Locales = "en";
@@ -42,10 +46,11 @@ void i18next.use(initReactI18next).init({
 
 /**
  * A localization function returned by the {@link useLocalize} hook.
- * @param {string} entryName The name of the localization key.
+ * @param {LocalizationNames} entryName The name of the localization key.
  * @param {string?} defaultValue A default value if a localization key is not found.
- * @param {object?} params The interpolation parameters for the localization function. E.g. `{ interpolationName: interpolationValue }`.
+ * @param {unknown} params The interpolation parameters for the localization function. E.g. `{ interpolationName: interpolationValue }`.
  * @param {boolean?} escapeValue A value indicating whether the special characters should be escaped with interpolation. The default value is `true`.
+ * @returns {string} The localized string.
  */
 export type LocalizeFunction = (entryName: LocalizationNames, defaultValue?: string, params?: unknown, escapeValue?: boolean) => string;
 

--- a/src/localization/en/long_texts.json
+++ b/src/localization/en/long_texts.json
@@ -1,0 +1,3 @@
+{
+    "skipUndefinedOnCodeEvaluationExplanation": "Skip reporting of undefined code evaluation value of JavaScript / TypeScript as everything results with an undefined value if no actual result value is available. This is the basic functionality of Chromium V8 JavaScript engine."
+}

--- a/src/localization/en/settings.json
+++ b/src/localization/en/settings.json
@@ -3,5 +3,6 @@
     "saveFailed": "Failed to save the settings.",
     "saveSuccess": "Settings were saved successfully.",
     "saveWindowPosition": "Save window position",
-    "preferences": "Preferences"
+    "preferences": "Preferences",
+    "skipUndefinedOnCodeEvaluation": "Skip undefined on code evaluation"
 }

--- a/src/localization/en/ui.json
+++ b/src/localization/en/ui.json
@@ -35,5 +35,7 @@
     "typeScriptFiles": "TypeScript files",
     "javaScriptFiles": "JavaScript files",
     "codeMenu": "Code",
-    "evaluateCode": "Evaluate code"
+    "evaluateCode": "Evaluate code",
+    "oneLineEvaluation": "One line evaluation mode",
+    "line": "Line"
 }

--- a/src/localization/en/ui.json
+++ b/src/localization/en/ui.json
@@ -37,5 +37,6 @@
     "codeMenu": "Code",
     "evaluateCode": "Evaluate code",
     "oneLineEvaluation": "One line evaluation mode",
-    "line": "Line"
+    "line": "Line",
+    "skipEnptyLinesOnResults": "Skip empty lines on results"
 }

--- a/src/localization/fi/long_texts.json
+++ b/src/localization/fi/long_texts.json
@@ -1,0 +1,3 @@
+{
+    "skipUndefinedOnCodeEvaluationExplanation": "Älä raportoi JavaScriptin / TypeScriptin undefined-arvoa koska jokainen koodi arvioidaan undefined-arvoksi jos oikeaa paluuarvoa ei ole saatavilla. Tämä on perustoiminto Chromium V8 JavaScript-moottorilla."
+}

--- a/src/localization/fi/settings.json
+++ b/src/localization/fi/settings.json
@@ -3,5 +3,6 @@
     "saveFailed": "Asetusten tallennus epäonnistui.",
     "saveSuccess": "Asetukset tallennettiin onnistuneesti.",
     "saveWindowPosition": "Tallenna ikkunan sijainti",
-    "preferences": "Asetukset"
+    "preferences": "Asetukset",
+    "skipUndefinedOnCodeEvaluation": "Ohita undefined-arvot koodin arvioinnissa"
 }

--- a/src/localization/fi/ui.json
+++ b/src/localization/fi/ui.json
@@ -35,5 +35,7 @@
     "typeScriptFiles": "TypeScript-tiedostot",
     "javaScriptFiles": "JavaScript-tiedostot",
     "codeMenu": "Koodi",
-    "evaluateCode": "Suorita koodi"
+    "evaluateCode": "Suorita koodi",
+    "oneLineEvaluation": "Yhden rivin suoritus-tila",
+    "line": "Rivi"
 }

--- a/src/localization/fi/ui.json
+++ b/src/localization/fi/ui.json
@@ -37,5 +37,6 @@
     "codeMenu": "Koodi",
     "evaluateCode": "Suorita koodi",
     "oneLineEvaluation": "Yhden rivin suoritus-tila",
-    "line": "Rivi"
+    "line": "Rivi",
+    "skipEnptyLinesOnResults": "Ohita tyhjä rivit tuloksesta"
 }

--- a/src/menu/AppMenu.tsx
+++ b/src/menu/AppMenu.tsx
@@ -69,23 +69,17 @@ const AppMenu = ({
             });
 
             // Filter out shortcuts that are not for the current platform
-            if ((osType === "macos" && e.metaKey) || (osType !== "macos" && e.ctrlKey)) {
-                keydItems = keydItems.filter(item => {
-                    return item.shortcut?.ctrlOrMeta === true;
-                });
-            }
+            keydItems = keydItems.filter(item => {
+                return (item.shortcut?.ctrlOrMeta ?? false) === (osType === "macos" && e.metaKey) || (osType !== "macos" && e.ctrlKey);
+            });
 
-            if (e.shiftKey) {
-                keydItems = keydItems.filter(item => {
-                    return item.shortcut?.shift === true;
-                });
-            }
+            keydItems = keydItems.filter(item => {
+                return item.shortcut?.shift ?? false === e.shiftKey;
+            });
 
-            if (e.altKey) {
-                keydItems = keydItems.filter(item => {
-                    return item.shortcut?.alt === true;
-                });
-            }
+            keydItems = keydItems.filter(item => {
+                return item.shortcut?.alt ?? false === e.altKey;
+            });
 
             if (keydItems.length > 0) {
                 e.stopPropagation();

--- a/src/menu/AppMenuToolbar.tsx
+++ b/src/menu/AppMenuToolbar.tsx
@@ -37,11 +37,11 @@ import { appToolbarItems, ToolBarItems } from "./ToolbarItems";
  */
 type AppMenuToolbarProps = {
     selectValues: {
-        [key: string]: string;
+        [key: string]: unknown;
     };
     disabledItems?: (MenuKeys | ToolBarItems)[];
     darkMode?: boolean;
-    onItemClick: (key: MenuKeys) => void;
+    onItemClick: (key: MenuKeys, checked?: boolean) => void;
     onSelectChange(value: string, name?: string): void;
 } & CommonProps;
 
@@ -61,8 +61,8 @@ const AppMenuToolbarComponent = ({
     const { translate } = useTranslate();
 
     const onToolbarItemInternal = React.useCallback(
-        (key: unknown) => {
-            onItemClick(key as MenuKeys);
+        (key: unknown, checked?: boolean) => {
+            onItemClick(key as MenuKeys, checked);
         },
         [onItemClick]
     );

--- a/src/menu/AppToolbar.tsx
+++ b/src/menu/AppToolbar.tsx
@@ -29,13 +29,14 @@ import { FieldNames } from "rc-select/lib/Select";
 import { CommonProps } from "../components/Types";
 import { TooltipObjectButton } from "../components/wrappers/TooltipObjectButton";
 import { SelectWithLabel } from "../components/wrappers/SelectWithLabel";
+import { ToolTipObjectToggleButton } from "../components/wrappers/ToolTipObjectToggleButton";
 
 export type ToolBarItem<T> = {
     icon?: React.ReactNode;
     title: string;
     tooltipTitle: string;
     clickActionObject?: T;
-    type: "button" | "select";
+    type: "button" | "select" | "toggle";
     options?: { value: string; label: string }[] | undefined;
     fieldNames?: FieldNames | undefined;
     name?: string;
@@ -50,10 +51,10 @@ export type ToolBarSeparator = "|";
 export type AppToolbarProps<T> = {
     toolBarItems: (ToolBarItem<T> | ToolBarSeparator)[];
     selectValues: {
-        [key: string]: string;
+        [key: string]: unknown;
     };
-    onItemClick: (item: T) => void;
-    onSelectChange(value: string, name?: string): void;
+    onItemClick: (item: T, checked?: boolean) => void;
+    onSelectChange(value: unknown, name?: string): void;
 } & CommonProps;
 
 // Type quard for tool bar item
@@ -74,8 +75,8 @@ const AppToolbarComponent = <T,>({
     onSelectChange,
 }: AppToolbarProps<T>) => {
     const onClick = React.useCallback(
-        (item: unknown) => {
-            onItemClick(item as T);
+        (item: unknown, checked?: boolean) => {
+            onItemClick(item as T, checked);
         },
         [onItemClick]
     );
@@ -107,9 +108,9 @@ const AppToolbarComponent = <T,>({
  */
 const createToolbarItem = <T,>(
     item: ToolBarItem<T>,
-    onClick: (item: unknown) => void,
-    onSelectChange: (value: string, name?: string) => void,
-    selectValues: { [key: string]: string },
+    onClick: (item: unknown, checked?: boolean) => void,
+    onSelectChange: (value: unknown, name?: string) => void,
+    selectValues: { [key: string]: unknown },
     index: number
 ): JSX.Element => {
     if (item.type === "button") {
@@ -133,7 +134,21 @@ const createToolbarItem = <T,>(
                 fieldNames={item.fieldNames}
                 valueChanged={onSelectChange}
                 name={item.name}
-                value={selectValues[item.name]}
+                value={selectValues[item.name] as string}
+                key={index}
+                disabled={item.disabled}
+            />
+        );
+    }
+
+    if (item.type === "toggle" && item.name) {
+        return (
+            <ToolTipObjectToggleButton //
+                icon={item.icon}
+                tooltipTitle={item.tooltipTitle}
+                objectData={item.clickActionObject}
+                onClick={onClick}
+                checked={selectValues[item.name] as boolean}
                 key={index}
                 disabled={item.disabled}
             />

--- a/src/menu/MenuItems.tsx
+++ b/src/menu/MenuItems.tsx
@@ -156,4 +156,5 @@ export type MenuKeys =
     | "save"
     | "saveAs"
     | "codeMenu"
-    | "evaluateCode";
+    | "evaluateCode"
+    | "oneLineEvaluation";

--- a/src/menu/ToolbarItems.tsx
+++ b/src/menu/ToolbarItems.tsx
@@ -1,7 +1,7 @@
 //@ts-expect-error - React is required for JSX
 import * as React from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faArrowsRotate, faCodeFork, faDoorOpen, faGear, faInfo, faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faArrowsRotate, faCodeFork, faDoorOpen, faGear, faInfo, faListOl, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { LocalizeFunction } from "../localization/Localization";
 
 import { SaveAsIcon, SaveIcon } from "../img/ImageExports";
@@ -90,6 +90,16 @@ export const appToolbarItems = (localize?: LocalizeFunction, darkMode?: boolean,
         clickActionObject: "saveAs",
         type: "button",
         disabled: disabledItems?.includes("saveAs"),
+    },
+    "|",
+    {
+        icon: <FontAwesomeIcon icon={faListOl} />,
+        title: localize?.("oneLineEvaluation") ?? "One line evaluation",
+        tooltipTitle: localize?.("oneLineEvaluation") ?? "One line evaluation",
+        clickActionObject: "oneLineEvaluation",
+        type: "toggle",
+        disabled: disabledItems?.includes("oneLineEvaluation"),
+        name: "oneLineEvaluation",
     },
 ];
 

--- a/src/utilities/app/Code.ts
+++ b/src/utilities/app/Code.ts
@@ -24,11 +24,22 @@ SOFTWARE.
 
 import { getAppState, runScript, runScriptLineByLine } from "../../components/app/TauriWrappers";
 import { ScriptType } from "../../components/Types";
-import { LocalizeFunction } from "../../localization/Localization";
 import { transpileTypeSctiptToJs } from "./TypeSciptTranspile";
 
+/**
+ * Evaluates the given JavaScript / TypeScript code and returns the result.
+ * @param {string} content - The JavaScript / TypeScript code to evaluate.
+ * @param {boolean} skipUndefined - Whether to skip undefined result values by returning an empty string instead.
+ * @param {ScriptType} scriptType - The script type. Either "javascript" or "typescript".
+ * @returns {Promise<string>} The result of the evaluation.
+ */
 const evalueateValue = async (content: string | undefined | null, skipUndefined: boolean, scriptType: ScriptType) => {
     if (content !== undefined && content !== null) {
+        // If the content is empty, return an empty string
+        if (content.replaceAll(/\s/g, "") === "") {
+            return "";
+        }
+
         const scriptValue = content;
         let script = "";
 
@@ -64,7 +75,15 @@ const evalueateValue = async (content: string | undefined | null, skipUndefined:
     return "";
 };
 
-const evalueateValueByLines = async (content: string | undefined | null, skipUndefined: boolean, skipEmptyLines: boolean, scriptType: ScriptType, translate: LocalizeFunction) => {
+/**
+ * Evaluates the given JavaScript / TypeScript code line by line and returns the result.
+ * @param {string} content - The JavaScript / TypeScript code to evaluate.
+ * @param {boolean} skipUndefined - Whether to skip undefined result values by returning an empty string instead.
+ * @param {boolean} skipEmptyLines - Whether to skip empty line evaluation in the result.
+ * @param {ScriptType} scriptType - The script type. Either "javascript" or "typescript".
+ * @returns {Promise<string>} The result of the evaluation.
+ */
+const evalueateValueByLines = async (content: string | undefined | null, skipUndefined: boolean, skipEmptyLines: boolean, scriptType: ScriptType) => {
     if (content !== undefined && content !== null) {
         const scriptValue = content;
         let script: string[] = [];
@@ -114,7 +133,7 @@ const evalueateValueByLines = async (content: string | undefined | null, skipUnd
                     value.splice(i, 1);
                     i--;
                 } else {
-                    value[i] = `${translate("line", "Line")}: ${line.toString().padStart(2, " ")}. ${value[i]}`;
+                    value[i] = `${line.toString().padStart(2, " ")}. ${value[i]}`;
                 }
                 line++;
             }

--- a/src/utilities/app/Settings.ts
+++ b/src/utilities/app/Settings.ts
@@ -40,6 +40,10 @@ export type Settings = {
     error: boolean;
     /** An error message if one occurred. */
     error_message: string;
+    /** A value indicating whether to skip undefined result values on JavaScript / TypeScript evaluation. */
+    skip_undefined_on_js: boolean;
+    /** A value indicating whether to skip empty result values on JavaScript / TypeScript evaluation. */
+    skip_empty_on_js: boolean;
 };
 
 /**


### PR DESCRIPTION
* Add setting for each file whether to evaluate the script line by line or all together. 
* Fix keyboard shortcut functionality.
* Add option whether to skip undefined values from the result data
* Add option to skip empty lines on script evaluation.

Closes #24 